### PR TITLE
Fix extraction when filename contains invalid unicode characters

### DIFF
--- a/src/SingleFileExtractor.Core/FileEntry.cs
+++ b/src/SingleFileExtractor.Core/FileEntry.cs
@@ -120,7 +120,7 @@ namespace SingleFileExtractor.Core
             // The entire filename is invalid, generate a new one so that subsequent extractions do not overwrite the same file
             if (Path.GetFileNameWithoutExtension(filteredFileName).Replace("_", String.Empty).Length == 0)
             {
-                System.Console.WriteLine(normalized, "is an invalid filename, replacing with random name");
+                System.Console.WriteLine(normalized + " is an invalid filename, replacing with random name");
                 filteredFileName = "invalid_" + Guid.NewGuid().ToString() + Path.GetExtension(filteredFileName);
             }
 


### PR DESCRIPTION
For a bundle with the invalid unicode filenames extraction would fail:
![image](https://github.com/Droppers/SingleFileExtractor/assets/6619205/fe694690-a05f-4d38-84da-5e9baf6d34ab)

Previously:
```
Bundle version: 2.0
Unexpected error while extracting:
System.IO.IOException: The filename, directory name, or volume label syntax is incorrect. : 'C:\Users\user\???????????????????????????????????????????????????????????????.dll'
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at SingleFileExtractor.Core.FileEntry.ExtractToFileAsync(String targetFileName, CancellationToken cancellationToken) in /Users/joery.droppers/pdev/SingleFileExtractor/src/SingleFileExtractor.Core/FileEntry.cs:line 53
   at SingleFileExtractor.Core.ExecutableReader.ExtractToDirectoryAsync(String outputDirectory, CancellationToken cancellationToken) in /Users/joery.droppers/pdev/SingleFileExtractor/src/SingleFileExtractor.Core/ExecutableReader.cs:line 94
   at Program.<<Main>$>g__RunExtractorAsync|0_2(String fileName, String outputDirectory, CancellationToken cancellationToken) in /Users/joery.droppers/pdev/SingleFileExtractor/src/SingleFileExtractor.CLI/Program.cs:line 68
```

Now:
```
Bundle version: 2.0
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
C:\Users\user\Desktop\ext\???????????????????????????????????????????????????????????????.dll is an invalid filename, replacing with random name
Extracted 552 files to "C:\Users\user\Desktop\ext\"
```