### PR TITLE
Bump Nuget versions and move to .NET 8.0

### DIFF
--- a/src/SingleFileExtractor.CLI/SingleFileExtractor.CLI.csproj
+++ b/src/SingleFileExtractor.CLI/SingleFileExtractor.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -31,7 +31,7 @@
     <None Include="NuGet.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SingleFileExtractor.Core\SingleFileExtractor.Core.csproj" />

--- a/src/SingleFileExtractor.Core/SingleFileExtractor.Core.csproj
+++ b/src/SingleFileExtractor.Core/SingleFileExtractor.Core.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2023.*" PrivateAssets="All"/>
-    <PackageReference Include="PolySharp" Version="1.14.0">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/SingleFileExtractor.Core.Tests/SingleFileExtractor.Core.Tests.csproj
+++ b/test/SingleFileExtractor.Core.Tests/SingleFileExtractor.Core.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Moving from .NET 6.0 (LTS) to .NET 8.0 (LTS). because .NET 6.0 is out of support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the application’s runtime to .NET 8.0 for improved performance and compatibility.
  - Updated key dependencies to benefit from the latest enhancements.

- **Tests**
  - Refreshed the testing framework and tooling for a more reliable and efficient testing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->